### PR TITLE
Add refresh token binding implementation consideration and update broken links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-oauth-attested-key-based-client-authentication/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/vcstuff/draft-looker-oauth-attested-key-based-client-authentication/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# OAuth2 Client Authentication for Sender Constrained Tokens
+# OAuth2 Attested Key Based Client Authentication
 
-This is the working area for the individual Internet-Draft, "OAuth2 Client Authentication for Sender Constrained Tokens".
+This is the working area for the individual Internet-Draft, "OAuth2 Attested Key Based Client Authentication".
 
-* [Editor's Copy](https://tplooker.github.io/draft-looker-oauth-attested-key-based-client-authentication/#go.draft-looker-oauth-attested-key-based-client-authentication.html)
+* [Editor's Copy](https://vcstuff.github.io/draft-looker-oauth-attested-key-based-client-authentication/#go.draft-looker-oauth-attested-key-based-client-authentication.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-looker-oauth-attested-key-based-client-authentication)
 * [Individual Draft](https://datatracker.ietf.org/doc/html/draft-looker-oauth-attested-key-based-client-authentication)
-* [Compare Editor's Copy to Individual Draft](https://tplooker.github.io/draft-looker-oauth-attested-key-based-client-authentication/#go.draft-looker-oauth-attested-key-based-client-authentication.diff)
+* [Compare Editor's Copy to Individual Draft](https://vcstuff.github.io/draft-looker-oauth-attested-key-based-client-authentication/#go.draft-looker-oauth-attested-key-based-client-authentication.diff)
 
 
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-oauth-attested-key-based-client-authentication/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/vcstuff/draft-looker-oauth-attested-key-based-client-authentication/blob/main/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.

--- a/draft-looker-oauth-attested-key-based-client-authentication.md
+++ b/draft-looker-oauth-attested-key-based-client-authentication.md
@@ -241,6 +241,10 @@ The following example is the decoded header and payload of a JWT meeting the pro
 
 Implementers should be aware that the design of this authentication mechanism deliberately allows for a client instance to re-use a single Client Attestation JWT in multiple interactions/requests with an authorization server, whilst producing a fresh Client Attestation PoP JWT. Client deployments should consider this when determining the validity period for issued Client Attestation JWTs as this ultimately controls how long a client instance can re-use a single Client Attestation JWT.
 
+## Refresh token binding
+
+Authorization servers issuing a refresh token in response to a token request using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" client authentication method MUST bind the refresh token to the client instance NOT just the client as specified in section 6 [@!RFC6749]. To prove this binding, the client instance MUST authenticate itself to the authorization server when refreshing an access token using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" authentication method. The client MUST also use the same client attestation key that was used for authentication when the refresh token was issued.
+
 # Security Considerations
 
 TODO

--- a/draft-looker-oauth-attested-key-based-client-authentication.md
+++ b/draft-looker-oauth-attested-key-based-client-authentication.md
@@ -243,7 +243,7 @@ Implementers should be aware that the design of this authentication mechanism de
 
 ## Refresh token binding
 
-Authorization servers issuing a refresh token in response to a token request using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" client authentication method MUST bind the refresh token to the client instance NOT just the client as specified in section 6 [@!RFC6749]. To prove this binding, the client instance MUST authenticate itself to the authorization server when refreshing an access token using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" authentication method. The client MUST also use the same client attestation key that was used for authentication when the refresh token was issued.
+Authorization servers issuing a refresh token in response to a token request using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" client authentication method MUST bind the refresh token to the client instance, and NOT just the client as specified in section 6 [@!RFC6749]. To prove this binding, the client instance MUST authenticate itself to the authorization server when refreshing an access token using the "urn:ietf:params:oauth:client-assertion-type:jwt-key-attestation" authentication method. The client MUST also use the same client attestation key that was used for authentication when the refresh token was issued.
 
 # Security Considerations
 


### PR DESCRIPTION
As discussed over email, this PR drafts some text to capture the requirement around refresh token binding to the client instance not just the client. The PR also addresses some broken links.

Personally I'm still not convinced that the best way to do this binding is through the client attestation key, instead I think we could add a claim that identifies the client instance in the client key attestation